### PR TITLE
Adjust colorful theme share menu and toggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -195,12 +195,12 @@ body.theme-originalcolor .social-link:hover {
     color: var(--bg-primary) !important;
 }
 
-/* OriginalColor theme share options */
-body.theme-originalcolor .share-option {
+/* Colorful theme share options */
+body:not(.theme-secondary) .share-option {
     color: #F2D338 !important;
 }
 
-body.theme-originalcolor .share-option:hover {
+body:not(.theme-secondary) .share-option:hover {
     background-color: var(--accent-primary);
     color: var(--border-primary) !important;
 }
@@ -212,12 +212,12 @@ body.theme-originalcolor .share-option:hover {
     flex-shrink: 0;
 }
 
-/* OriginalColor theme share option svg */
-body.theme-originalcolor .share-option svg {
+/* Colorful theme share option svg */
+body:not(.theme-secondary) .share-option svg {
     fill: #F2D338 !important;
 }
 
-body.theme-originalcolor .share-option:hover svg {
+body:not(.theme-secondary) .share-option:hover svg {
     fill: var(--border-primary) !important;
 }
 
@@ -226,12 +226,12 @@ body.theme-originalcolor .share-option:hover svg {
     color: var(--bg-primary) !important;
 }
 
-/* OriginalColor theme share option span */
-body.theme-originalcolor .share-option span {
+/* Colorful theme share option span */
+body:not(.theme-secondary) .share-option span {
     color: #F2D338 !important;
 }
 
-body.theme-originalcolor .share-option:hover span {
+body:not(.theme-secondary) .share-option:hover span {
     color: var(--border-primary) !important;
 }
 
@@ -293,12 +293,12 @@ body.theme-originalcolor .share-option:hover span {
     animation: pulse 2s ease-in-out infinite;
 }
 
-/* OriginalColor theme scrolling text */
-body.theme-originalcolor .initial-message {
+/* Scrolling text color for default (colorful) theme */
+body:not(.theme-secondary) .initial-message {
     color: #F2D338;
 }
 
-body.theme-originalcolor .scrolling-message {
+body:not(.theme-secondary) .scrolling-message {
     color: #F2D338;
 }
 
@@ -774,8 +774,8 @@ body.theme-originalcolor .install-btn:hover {
     }
 }
 
-/* Theme toggle icon rotation when active */
-body.theme-originalcolor .theme-toggle {
+/* Colorful theme toggle button */
+body:not(.theme-secondary) .theme-toggle {
     background: linear-gradient(45deg, #ffffff, #888888, #333333, #000000);
     background-size: 400% 400%;
     animation: gradientShift 2s ease infinite, rotateIcon 0.5s ease;


### PR DESCRIPTION
## Summary
- ensure share menu icons and text turn yellow in the colorful theme
- switch theme toggle gradient to greyscale when colorful theme is active

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e8560cee48328944223e7dbd10c85