### PR TITLE
Fix PWA manifest and add image hints

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,8 @@
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://sonic2.sistemahost.es" crossorigin>
+    <link rel="preload" as="image" href="assets/logo.webp" type="image/webp">
     <link href="https://fonts.googleapis.com/css2?family=Doto:wght@100..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
@@ -151,7 +153,7 @@
     <main class="main-content" role="main">
         <div class="player-container">
             <!-- TODO: Replace with actual station logo -->
-            <img id="logo-btn" src="assets/logo.webp" alt="Bahia FM logo - click to play/pause radio" class="station-logo">
+            <img id="logo-btn" src="assets/logo.webp" alt="Bahia FM logo - click to play/pause radio" class="station-logo" width="1024" height="1024">
             <div class="controls">
 
                 <button id="mute-btn" class="control-btn" aria-label="Mute/Unmute"><i class="fa-solid fa-volume-high"></i></button>
@@ -175,7 +177,7 @@
 
     <!-- SurfFactory Button (moved to bottom left) -->
     <a href="https://www.surfactory.pt/" target="_blank" rel="noopener noreferrer" class="surf-btn" aria-label="SurfFactory">
-        <img src="assets/SurfFactory_PT.webp" alt="SurfFactory" />
+        <img src="assets/SurfFactory_PT.webp" alt="SurfFactory" width="591" height="259" />
     </a>
 
     <!-- Theme Toggle Button -->

--- a/manifest.json
+++ b/manifest.json
@@ -38,20 +38,6 @@
       ]
     }
   ],
-  "screenshots": [
-    {
-      "src": "assets/screenshot1.png",
-      "sizes": "540x720",
-      "type": "image/png",
-      "form_factor": "narrow"
-    },
-    {
-      "src": "assets/screenshot2.png",
-      "sizes": "720x540",
-      "type": "image/png",
-      "form_factor": "wide"
-    }
-  ],
   "related_applications": [],
   "prefer_related_applications": false,
   "edge_side_panel": {


### PR DESCRIPTION
## Summary
- remove unused screenshot entries from `manifest.json`
- hint browsers to preload the logo and preconnect to the streaming domain
- add explicit dimensions for images to reduce layout shift

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a4bb4a92483288d8b5f7a64e1e1e6