### PR TITLE
Adjust GA4 consent handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,23 +19,7 @@
         // No manual consent calls - Cookiebot will handle this automatically
         gtag('config', 'G-4BFB1KMVW1', { send_page_view: false });
         
-        // Install state detection function
-        function isAppInstalled() {
-            return (
-                window.matchMedia('(display-mode: standalone)').matches ||
-                window.navigator.standalone === true ||
-                document.referrer.startsWith('android-app://')
-            );
-        }
-        
-        // Set user properties after Cookiebot consent is handled
-        window.addEventListener('CookiebotOnAccept', () => {
-            if (Cookiebot.consent.statistics) {
-                gtag('set', 'user_properties', {
-                    install_state: isAppInstalled() ? 'installed' : 'browser'
-                });
-            }
-        });
+        // GA4 events will be fired from app.js once consent is granted
     </script>
     <!-- End Google Analytics GA4 -->
     


### PR DESCRIPTION
## Summary
- clean up GA4 snippet in *index.html*
- centralize `isAppInstalled` and analytics events in *app.js*
- send page view after consent using `CookiebotOnAccept`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a4f06abb8832890b0fd99cadbd447